### PR TITLE
Fix 2d rig

### DIFF
--- a/build_rigs.py
+++ b/build_rigs.py
@@ -283,6 +283,12 @@ def create_2d_bones(context, rig, cam):
     for bone in pose_bones:
         bone.rotation_mode = 'XYZ'
 
+    # Lens property
+    pb = pose_bones['Camera']
+    pb["lens"] = 50.0
+    ui_data = pb.id_properties_ui("lens")
+    ui_data.update(min=1.0, max=1000000.0, soft_max = 5000.0, default=50.0)
+
     # Bone drivers
     center_drivers = pose_bones["MCH-Center"].driver_add("location")
 
@@ -380,7 +386,7 @@ def create_2d_bones(context, rig, cam):
     var.targets[0].data_path = 'pose.bones["Camera"]["rotation_shift"]'
 
     # Focal length driver
-    driver = cam.data.driver_add('lens').driver
+    driver = pose_bones["Camera"].driver_add('["lens"]').driver
     driver.expression = 'abs({distance_z} - (left_z + right_z)/2 + cam_z) * 36 / frame_width'.format(
         distance_z=corner_distance_z)
 
@@ -457,9 +463,8 @@ def create_2d_bones(context, rig, cam):
     var = driver.variables.new()
     var.name = 'lens'
     var.type = 'SINGLE_PROP'
-    var.targets[0].id_type = 'CAMERA'
-    var.targets[0].id = cam.data
-    var.targets[0].data_path = 'lens'
+    var.targets[0].id = rig
+    var.targets[0].data_path = 'pose.bones["Camera"]["lens"]'
 
     # Shift driver Y
     driver = cam.data.driver_add('shift_y').driver
@@ -502,9 +507,8 @@ def create_2d_bones(context, rig, cam):
     var = driver.variables.new()
     var.name = 'lens'
     var.type = 'SINGLE_PROP'
-    var.targets[0].id_type = 'CAMERA'
-    var.targets[0].id = cam.data
-    var.targets[0].data_path = 'lens'
+    var.targets[0].id = rig
+    var.targets[0].data_path = 'pose.bones["Camera"]["lens"]'
 
 
 def build_camera_rig(context, mode):
@@ -574,6 +578,7 @@ def build_camera_rig(context, mode):
     # on the armature
     create_prop_driver(rig, cam, "focus_distance", "dof.focus_distance")
     create_prop_driver(rig, cam, "aperture_fstop", "dof.aperture_fstop")
+    create_prop_driver(rig, cam, "lens", "lens")
 
     # Make the rig the active object
     view_layer = context.view_layer

--- a/build_rigs.py
+++ b/build_rigs.py
@@ -227,9 +227,8 @@ def setup_3d_rig(rig, cam):
     var.targets[0].bone_target = 'Root'
 
 
-def create_2d_bones(context, rig, cam):
+def create_2d_bones(rig, cam):
     """Create bones for the 2D camera rig"""
-    scene = context.scene
     bones = rig.data.edit_bones
 
     # Add new bones
@@ -324,9 +323,8 @@ def create_2d_bones(context, rig, cam):
 
         var = driver.variables.new()
         var.name = 'res_' + direction
-        var.type = 'SINGLE_PROP'
-        var.targets[0].id_type = 'SCENE'
-        var.targets[0].id = scene
+        var.type = 'CONTEXT_PROP'
+        var.targets[0].context_property = 'ACTIVE_SCENE'
         var.targets[0].data_path = 'render.resolution_' + direction
 
     # Center Z driver
@@ -500,8 +498,8 @@ def create_2d_bones(context, rig, cam):
         var = driver.variables.new()
         var.name = 'res_' + direction
         var.type = 'SINGLE_PROP'
-        var.targets[0].id_type = 'SCENE'
-        var.targets[0].id = scene
+        var.type = 'CONTEXT_PROP'
+        var.targets[0].context_property = 'ACTIVE_SCENE'
         var.targets[0].data_path = 'render.resolution_' + direction
 
     var = driver.variables.new()
@@ -536,7 +534,7 @@ def build_camera_rig(context, mode):
         create_crane_bones(rig)
         setup_3d_rig(rig, cam)
     elif mode == "2D":
-        create_2d_bones(context, rig, cam)
+        create_2d_bones(rig, cam)
 
     # Parent the camera to the rig
     cam.location = (0.0, -1.0, 0.0)  # Move the camera to the correct position


### PR DESCRIPTION
- Fix #10: Add lens property to camera bone (2d rig) to set as driver
- 2D rig: Use contextual driver variable for the current scene
  This avoids passing the current scene around through the context, and
  makes the rig work when multiple scenes with different resolutions are
  used.