### PR TITLE
Refresh UI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-import bpy
-import os
-
 from . import build_rigs
 from . import operators
 from . import ui_panels

--- a/build_rigs.py
+++ b/build_rigs.py
@@ -27,7 +27,7 @@ def create_prop_driver(rig, cam, prop_from, prop_to):
     var.targets[0].data_path = 'pose.bones["Camera"]["%s"]' % prop_from
     driver.driver.expression = prop_from
 
-    return(driver)
+    return driver
 
 
 def create_dolly_bones(rig):

--- a/build_rigs.py
+++ b/build_rigs.py
@@ -164,7 +164,7 @@ def setup_3d_rig(rig, cam):
     pb = pose_bones['Camera']
     pb["lens"] = 50.0
     ui_data = pb.id_properties_ui("lens")
-    ui_data.update(min=1.0, max=1000000.0, soft_max = 5000.0, default=50.0)
+    ui_data.update(min=1.0, max=1000000.0, soft_max=5000.0, default=50.0, subtype="DISTANCE_CAMERA")
 
     # lens offset property
     pb = pose_bones['Camera']

--- a/build_rigs.py
+++ b/build_rigs.py
@@ -19,13 +19,13 @@ def create_prop_driver(rig, cam, prop_from, prop_to):
     driver = cam.data.driver_add(prop_to)
     driver.driver.type = 'SCRIPTED'
     var = driver.driver.variables.new()
-    var.name = '%s' % prop_from
+    var.name = prop_from
     var.type = 'SINGLE_PROP'
 
     # Target the custom bone property
     var.targets[0].id = rig
     var.targets[0].data_path = 'pose.bones["Camera"]["%s"]' % prop_from
-    driver.driver.expression = '%s' % prop_from
+    driver.driver.expression = prop_from
 
     return(driver)
 
@@ -519,7 +519,7 @@ def build_camera_rig(context, mode):
     rig_name = mode.capitalize() + "_Rig"
     rig_data = bpy.data.armatures.new(rig_name)
     rig = object_utils.object_data_add(context, rig_data, name=rig_name)
-    rig["rig_id"] = "%s" % rig_name
+    rig["rig_id"] = rig_name
     rig.location = context.scene.cursor.location
 
     bpy.ops.object.mode_set(mode='EDIT')

--- a/operators.py
+++ b/operators.py
@@ -37,10 +37,15 @@ def calculate_aim_distance(obj):
 class CameraRigMixin():
     @classmethod
     def poll(cls, context):
-        if context.active_object is not None:
-            return get_rig_and_cam(context.active_object) != (None, None)
-
-        return False
+        if context.active_object is None:
+            if hasattr(cls, "poll_message_set"):
+                cls.poll_message_set("No object is selected.")
+            return False
+        if None in get_rig_and_cam(context.active_object):
+            if hasattr(cls, "poll_message_set"):
+                cls.poll_message_set("Active object is not in a camera rig.")
+            return False
+        return True
 
 
 class ADD_CAMERA_RIGS_OT_set_scene_camera(Operator):
@@ -50,12 +55,17 @@ class ADD_CAMERA_RIGS_OT_set_scene_camera(Operator):
 
     @classmethod
     def poll(cls, context):
-        if context.active_object is not None:
-            rig, cam = get_rig_and_cam(context.active_object)
-            if cam is not None:
-                return cam is not context.scene.camera
-
-        return False
+        if context.active_object is None:
+            cls.poll_message_set("No object is selected.")
+            return False
+        rig, cam = get_rig_and_cam(context.active_object)
+        if cam is None:
+            cls.poll_message_set("Active object is not in a camera rig.")
+            return False
+        if cam is context.scene.camera:
+            cls.poll_message_set("Selected camera is already the scene camera.")
+            return False
+        return True
 
     def execute(self, context):
         rig, cam = get_rig_and_cam(context.active_object)

--- a/operators.py
+++ b/operators.py
@@ -148,7 +148,7 @@ class ADD_CAMERA_RIGS_OT_remove_dolly_zoom(Operator, CameraRigMixin):
         rig.pose.bones["Camera"]["lens"] = lens_value
 
         # reset the offset back to zero
-        rig.pose.bones["Camera"]["lens_offset"] = 0
+        rig.pose.bones["Camera"]["lens_offset"] = 0.0
 
         #set the bone color to default
         rig.pose.bones["Aim"].color.palette = 'DEFAULT'

--- a/operators.py
+++ b/operators.py
@@ -176,8 +176,9 @@ class ADD_CAMERA_RIGS_OT_swap_lens(Operator, CameraRigMixin):
     camera_lens: bpy.props.FloatProperty(
         name="Focal Length (mm)",
         default=50,
-        min = 1,
-        max = 1000,
+        min=1,
+        max=1000,
+        subtype='DISTANCE_CAMERA',
         description="The value of the new focal length",
     )
 

--- a/prefs.py
+++ b/prefs.py
@@ -26,8 +26,7 @@ class AddCameraRigsPreferences(AddonPreferences):
     def draw(self, context):
         layout = self.layout
 
-        row = layout.row()
-        col = row.column()
+        col = layout.column()
         col.prop(self, "widget_prefix", text="Widget Prefix")
         col.prop(self, "camera_widget_collection_name", text="Collection name")
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -25,8 +25,7 @@ class ADD_CAMERA_RIGS_PT_camera_rig_ui(Panel, CameraRigMixin):
         if rig["rig_id"].lower() in ("dolly_rig", "crane_rig"):
             drv = cam.data.animation_data.drivers[0]
             if drv.driver.expression == "lens":
-                layout.prop(pose_bones["Camera"], '["lens"]',
-                            text="Focal Length (mm)")
+                layout.prop(pose_bones["Camera"], '["lens"]', text="Focal Length")
                 layout.operator("add_camera_rigs.set_dolly_zoom")
             else:
                 layout.prop(pose_bones["Camera"], '["lens_offset"]',

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3,132 +3,205 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import bpy
-from bpy.types import Panel
+from bpy.types import Menu, Panel
 
 from .operators import get_rig_and_cam, CameraRigMixin
 
 
-class ADD_CAMERA_RIGS_PT_camera_rig_ui(Panel, CameraRigMixin):
-    bl_label = "Camera Rig"
+class CameraRigUIMixin(CameraRigMixin):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = 'Item'
 
+
+class ADD_CAMERA_RIGS_MT_lens_ops(Menu):
+    bl_label = "Camera Rig Lens Specials"
+
     def draw(self, context):
         active_object = context.active_object
-        rig, cam = get_rig_and_cam(context.active_object)
-        pose_bones = rig.pose.bones
+        _rig, cam = get_rig_and_cam(active_object)
         cam_data = cam.data
         layout = self.layout
 
+        drv = cam_data.animation_data.drivers[0]
+        if drv.driver.expression == "lens":
+            layout.operator("add_camera_rigs.set_dolly_zoom")
+        else:
+            layout.operator("add_camera_rigs.remove_dolly_zoom")
+
+        layout.operator("add_camera_rigs.shift_to_pivot")
+        layout.operator("add_camera_rigs.swap_lens")
+
+
+class ADD_CAMERA_RIGS_PT_camera_rig_ui(Panel, CameraRigUIMixin):
+    bl_label = "Camera Rig"
+
+    def draw(self, context):
+        active_object = context.active_object
+        rig, cam = get_rig_and_cam(active_object)
+        pose_bones = rig.pose.bones
+        cam_data = cam.data
+        layout = self.layout
+        layout.use_property_split = True
+
         # Camera lens
         if rig["rig_id"].lower() in ("dolly_rig", "crane_rig"):
-            drv = cam.data.animation_data.drivers[0]
+            col = layout.column(align=True)
+            drv = cam_data.animation_data.drivers[0]
+            row = col.row(align=False)
             if drv.driver.expression == "lens":
-                layout.prop(pose_bones["Camera"], '["lens"]', text="Focal Length")
-                layout.operator("add_camera_rigs.set_dolly_zoom")
+                row.prop(pose_bones["Camera"], '["lens"]', text="Focal Length")
             else:
-                layout.prop(pose_bones["Camera"], '["lens_offset"]',
-                            text="Lens offset")
-                col = layout.column(align=False)
-                col.prop(cam_data, "lens")
-                col.enabled = False
-                layout.operator("add_camera_rigs.remove_dolly_zoom")
-            
-            layout.operator("add_camera_rigs.shift_to_pivot")
-            layout.operator("add_camera_rigs.swap_lens")
-                
+                row.prop(pose_bones["Camera"], '["lens_offset"]',
+                        text="Lens Offset")
+                sub = col.row(align=False)
+                sub.enabled = False
+                sub.prop(cam_data, "lens")
+            row.menu("ADD_CAMERA_RIGS_MT_lens_ops", icon='DOWNARROW_HLT', text="")
 
-        col = layout.column(align=True)
-        col.label(text="Clipping:")
-        col.prop(cam_data, "clip_start", text="Start")
-        col.prop(cam_data, "clip_end", text="End")
+            col = layout.column(align=True)
+            col.prop(cam_data, "shift_x", text="Shift X")
+            col.prop(cam_data, "shift_y", text="Y")
 
-        col = layout.column(align=True)
-        col.label(text="Shift:")
-        col.prop(cam_data, "shift_x", text="X")
-        col.prop(cam_data, "shift_y", text="Y")
+        # 2D rig stuff
+        elif rig["rig_id"].lower() == "2d_rig":
+            col = layout.column(align=True)
+            col.prop(pose_bones["Camera"], '["rotation_shift"]',
+                    text="Rotation/Shift")
+            if cam.data.sensor_width != 36:
+                col.label(text="Please set Camera Sensor Width to 36", icon="ERROR")
+
+        sub = layout.column(align=True)
+        sub.prop(cam_data, "clip_start", text="Clip Start")
+        sub.prop(cam_data, "clip_end", text="End")
 
         layout.prop(cam_data, "type")
 
-        # DoF
-        col = layout.column(align=False)
-        col.prop(cam_data.dof, "use_dof")
-        if cam_data.dof.use_dof:
-            sub = col.column(align=True)
-            if cam_data.dof.focus_object is None:
-                sub.operator("add_camera_rigs.set_dof_bone")
-            sub.prop(cam_data.dof, "focus_object")
-            if (cam_data.dof.focus_object is not None
-                    and cam_data.dof.focus_object.type == 'ARMATURE'):
-                sub.prop_search(cam_data.dof, "focus_subtarget",
-                                cam_data.dof.focus_object.data, "bones")
-            sub = col.column(align=True)
-            row = sub.row(align=True)
-            row.active = cam_data.dof.focus_object is None
-            row.prop(pose_bones["Camera"],
-                     '["focus_distance"]', text="Focus Distance")
-            sub.prop(pose_bones["Camera"],
-                     '["aperture_fstop"]', text="F-Stop")
 
-        # Viewport display
-        layout.prop(active_object, 'show_in_front',
-                    toggle=False, text='Show in Front')
-        layout.prop(cam_data, "show_limits")
-        col = layout.column(align=True)
-        col.prop(cam_data, "show_passepartout")
-        if cam_data.show_passepartout:
-            col.prop(cam_data, "passepartout_alpha")
+class ADD_CAMERA_RIGS_PT_camera_rig_ui_dof(Panel, CameraRigUIMixin):
+    bl_label = "Depth of Field"
+    bl_parent_id = "ADD_CAMERA_RIGS_PT_camera_rig_ui"
+
+    def draw_header(self, context):
+        active_object = context.active_object
+        _rig, cam = get_rig_and_cam(active_object)
+
+        layout = self.layout
+        layout.prop(cam.data.dof, "use_dof", text="")
+
+    def draw(self, context):
+        active_object = context.active_object
+        rig, cam = get_rig_and_cam(active_object)
+        pose_bones = rig.pose.bones
+        cam_data = cam.data
+        layout = self.layout
+        layout.use_property_split = True
+
+        col = layout.column(align=False)
+        col.active = cam_data.dof.use_dof
+        if cam_data.dof.focus_object is None:
+            col.operator("add_camera_rigs.set_dof_bone")
+        sub = col.column(align=True)
+        sub.prop(cam_data.dof, "focus_object", text="Focus on Object")
+        if (cam_data.dof.focus_object is not None
+                and cam_data.dof.focus_object.type == 'ARMATURE'):
+            sub.prop_search(cam_data.dof, "focus_subtarget",
+                            cam_data.dof.focus_object.data, "bones")
+
+        row = col.row(align=True)
+        row.active = cam_data.dof.focus_object is None
+        row.prop(pose_bones["Camera"],
+                '["focus_distance"]', text="Focus Distance")
+        col.prop(pose_bones["Camera"],
+                '["aperture_fstop"]', text="F-Stop")
+
+
+class ADD_CAMERA_RIGS_PT_camera_rig_ui_viewport(Panel, CameraRigUIMixin):
+    bl_label = "Viewport Display"
+    bl_parent_id = "ADD_CAMERA_RIGS_PT_camera_rig_ui"
+
+    def draw(self, context):
+        active_object = context.active_object
+        _rig, cam = get_rig_and_cam(active_object)
+        cam_data = cam.data
+        layout = self.layout
+        layout.use_property_split = True
+
+        col = layout.column(align=False, heading="Show")
+        col.prop(active_object, 'show_in_front',
+                    toggle=False, text='In Front')
+        col.prop(cam_data, "show_limits", text="Limits")
+
+        col = layout.column(align=False, heading="Passepartout")
+        col.use_property_decorate = False
+        row = col.row(align=True)
+        sub = row.row(align=True)
+        sub.prop(cam_data, "show_passepartout", text="")
+        sub = sub.row(align=True)
+        sub.active = cam_data.show_passepartout
+        sub.prop(cam_data, "passepartout_alpha", text="")
+        row.prop_decorator(cam_data, "passepartout_alpha")
 
         # Composition guides
-        layout.popover(
+        col.separator()
+        col.popover(
             panel="ADD_CAMERA_RIGS_PT_composition_guides",
-            text="Composition Guides",)
+            text="Composition Guides",
+        )
 
-        # Props and operators
+
+class ADD_CAMERA_RIGS_PT_camera_rig_ui_visibility(Panel, CameraRigUIMixin):
+    bl_label = "Rig Properties"
+    bl_parent_id = "ADD_CAMERA_RIGS_PT_camera_rig_ui"
+
+    def draw(self, context):
+        active_object = context.active_object
+        rig, cam = get_rig_and_cam(active_object)
+        pose_bones = rig.pose.bones
+        layout = self.layout
+
         col = layout.column(align=True)
-        col.prop(cam,
-                    "hide_select", text="Make Camera Unselectable")
+        col.prop(cam, "hide_select", text="Make Camera Unselectable")
         col.operator("add_camera_rigs.add_marker_bind",
                      text="Add Marker and Bind", icon="MARKER_HLT")
         col.operator("add_camera_rigs.set_scene_camera",
                      text="Make Camera Active", icon='CAMERA_DATA')
 
         if rig["rig_id"].lower() in ("dolly_rig", "crane_rig"):
+            layout.use_property_split = True
+
             # Track to Constraint
-            col = layout.column(align=True)
             track_to_constraint = None
             for con in pose_bones["Camera"].constraints:
                 if con.type == 'TRACK_TO':
                     track_to_constraint = con
                     break
             if track_to_constraint is not None:
-                col.label(text="Tracking:")
+                col = layout.column(align=True)
                 col.prop(track_to_constraint, 'influence',
                          text="Aim Lock", slider=True)
 
             # Crane arm stuff
             if rig["rig_id"].lower() == "crane_rig":
                 col = layout.column(align=True)
-                col.label(text="Crane Arm:")
                 col.prop(pose_bones["Crane_Height"],
-                         'scale', index=1, text="Arm Height")
+                         'scale', index=1, text="Crane Arm Height")
                 col.prop(pose_bones["Crane_Arm"],
-                         'scale', index=1, text="Arm Length")
-
-        # 2D rig stuff
-        elif rig["rig_id"].lower() == "2d_rig":
-            col = layout.column(align=True)
-            col.label(text="2D Rig:")
-            col.prop(pose_bones["Camera"], '["rotation_shift"]',
-                     text="Rotation/Shift")
-            if cam.data.sensor_width != 36:
-                col.label(text="Please set Camera Sensor Width to 36", icon="ERROR")
+                         'scale', index=1, text="Length")
 
 
 def register():
+
+    bpy.utils.register_class(ADD_CAMERA_RIGS_MT_lens_ops)
     bpy.utils.register_class(ADD_CAMERA_RIGS_PT_camera_rig_ui)
+    bpy.utils.register_class(ADD_CAMERA_RIGS_PT_camera_rig_ui_dof)
+    bpy.utils.register_class(ADD_CAMERA_RIGS_PT_camera_rig_ui_viewport)
+    bpy.utils.register_class(ADD_CAMERA_RIGS_PT_camera_rig_ui_visibility)
 
 
 def unregister():
+    bpy.utils.unregister_class(ADD_CAMERA_RIGS_MT_lens_ops)
     bpy.utils.unregister_class(ADD_CAMERA_RIGS_PT_camera_rig_ui)
+    bpy.utils.unregister_class(ADD_CAMERA_RIGS_PT_camera_rig_ui_dof)
+    bpy.utils.unregister_class(ADD_CAMERA_RIGS_PT_camera_rig_ui_viewport)
+    bpy.utils.unregister_class(ADD_CAMERA_RIGS_PT_camera_rig_ui_visibility)


### PR DESCRIPTION
This is a proposition for a new UI layout that more closely adheres to Blender’s conventions:
- Use subpanels to group related properties.
- Use split properties with decorations (dot to insert keys).
- Disable DOF properties instead of hiding them, to avoid the UI jumping around.
- Put focal-related operators (Set Dolly Zoom, etc.) inside a menu next to the main property.
- Use mm as unit (property subtype) for the focal length. This avoids adding it to the UI text.
- Add poll methods to the operators, to let the user know why an operator cannot be used.

| Before | After |
|--------|--------|
|  ![image](https://github.com/user-attachments/assets/6a6f87a1-af29-402b-9b89-2b2b2f009fd1) | ![image](https://github.com/user-attachments/assets/d69ded0f-fcd6-42fe-b4a5-f196cab958e4) |

I think this is an improvement but it’s mostly subjective so I don’t expect all the changes to go in. Still, worth testing!