### PR TITLE
Add exclude paths to the manifest

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -16,3 +16,15 @@ copyright = [
     "2024 Damien Picard",
     "2024 Flavio Perez",
 ]
+
+[build]
+paths_exclude_pattern = [
+  "/.git/",
+  "__pycache__/",
+  "images/",
+  ".*",
+  "*.blend",
+  "*.blend[0123456789]",
+  "*.md",
+  "*.zip",
+]


### PR DESCRIPTION
This allows building the add-on with `blender -c extension build`, without having unwanted files in the resulting .zip file.